### PR TITLE
feat(liquidity): showing where to get ERC-20 DFI when balance = 0

### DIFF
--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -206,7 +206,7 @@ export default function CurrencyInputPanel({
               {account && currency && showMaxButton && label !== 'To' && (
                 <StyledBalanceMax onClick={onMax}>MAX</StyledBalanceMax>
               )}
-              {showGetDFI ? <StyledBalanceMax onClick={() => window.open(pathLink)}>Get DFI!!</StyledBalanceMax> : ''}
+              {showGetDFI ? <StyledBalanceMax onClick={() => window.open(pathLink)}>Get DFI</StyledBalanceMax> : ''}
             </>
           )}
           <CurrencySelect

--- a/src/components/CurrencyInputPanel/index.tsx
+++ b/src/components/CurrencyInputPanel/index.tsx
@@ -121,6 +121,7 @@ interface CurrencyInputPanelProps {
   onUserInput: (value: string) => void
   onMax?: () => void
   showMaxButton: boolean
+  showGetDFI?: boolean
   label?: string
   onCurrencySelect?: (currency: Currency) => void
   currency?: Currency | null
@@ -139,6 +140,7 @@ export default function CurrencyInputPanel({
   onUserInput,
   onMax,
   showMaxButton,
+  showGetDFI,
   label = 'Input',
   onCurrencySelect,
   currency,
@@ -152,6 +154,10 @@ export default function CurrencyInputPanel({
   customBalanceText
 }: CurrencyInputPanelProps) {
   const { t } = useTranslation()
+
+  //Navigation
+  const pathLink =
+    'https://birthdayresearch.notion.site/DFI-Liquidity-Mining-Program-1696a9cb66fd4fc38d9ccf14c782cba0#2115244652264ef192174da5d2c047de'
 
   const [modalOpen, setModalOpen] = useState(false)
   const { account } = useActiveWeb3React()
@@ -200,6 +206,7 @@ export default function CurrencyInputPanel({
               {account && currency && showMaxButton && label !== 'To' && (
                 <StyledBalanceMax onClick={onMax}>MAX</StyledBalanceMax>
               )}
+              {showGetDFI ? <StyledBalanceMax onClick={() => window.open(pathLink)}>Get DFI!!</StyledBalanceMax> : ''}
             </>
           )}
           <CurrencySelect

--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -285,7 +285,7 @@ export default function FullPositionCard({ pair, border, stakedBalance, claimabl
   let aprValue: number = 0
   if (pair && totalSupply && checkRewardContract() && checkTotalStake()) {
     aprValue = apr(pair, totalSupply, checkRewardContract(), checkTotalStake())
-    console.log(aprValue, chainId)
+    //console.log(aprValue, chainId)
   }
 
   return (

--- a/src/constants/abis/eth-lp-proxy.json
+++ b/src/constants/abis/eth-lp-proxy.json
@@ -23,7 +23,7 @@
       },
       {
         "internalType": "uint256",
-        "name": "_rewardSpeed",
+        "name": "_admin_speed",
         "type": "uint256"
       }
     ],
@@ -288,6 +288,19 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "admin_speed",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -312,7 +325,12 @@
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "",
+        "name": "_rewardForRecipient",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_totalRewardAccrued",
         "type": "uint256"
       }
     ],
@@ -334,6 +352,19 @@
   },
   {
     "inputs": [],
+    "name": "contract_stage",
+    "outputs": [
+      {
+        "internalType": "enum LiquidityMiningLogic.STAGE",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "emergency",
     "outputs": [
       {
@@ -343,19 +374,6 @@
       }
     ],
     "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "_rewardSpeed",
-        "type": "uint256"
-      }
-    ],
-    "name": "endColdStart",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -374,6 +392,13 @@
   {
     "inputs": [],
     "name": "enterEmergencyMode",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "enterNextStage",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -429,19 +454,6 @@
       }
     ],
     "name": "hasRole",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "inColdStart",
     "outputs": [
       {
         "internalType": "bool",
@@ -875,6 +887,19 @@
         "internalType": "bool",
         "name": "",
         "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalRewardAccrued",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -79,64 +79,64 @@ export const USDC: { [chainId in ChainId]: Token } = {
 }
 
 // Proxy contact addresses
-export const PROXIES: ProxyInfo[] = [
-  {
-    //Need to update the address with Mainnet
-    address: '0xC13A1F46B58fCe16C3A583DF8E26BbeF1a497aD2',
-    chainId: ChainId.MAINNET,
-    symbol: 'USDT',
-    underlyingPairAddress: '0x9e251daEB17981477509779612dC2FFa8075AA8E',
-    tokenA: DFI[ChainId.MAINNET],
-    tokenB: USDT[ChainId.MAINNET]
-  },
-  {
-    //Need to update the address with Mainnet
-    address: '0x8cc61dfd87b256ce2be3da9ffa98ede3f018fa0e',
-    chainId: ChainId.MAINNET,
-    symbol: 'USDC',
-    underlyingPairAddress: '0xd239216ac7E44A09dA67d6852CD757fc5e829FE2',
-    tokenA: DFI[ChainId.MAINNET],
-    tokenB: USDC[ChainId.MAINNET]
-  },
-  {
-    //Need to update the address with Mainnet
-    address: '0x743c5b2f134290741b6de9c330d5a2ff43c773d3',
-    chainId: ChainId.MAINNET,
-    symbol: 'WETH',
-    underlyingPairAddress: '0xb079D6bE3faf5771e354586DbC47d0a3D37C34fb',
-    tokenA: DFI[ChainId.MAINNET],
-    tokenB: WETH[ChainId.MAINNET]
-  }
-]
 // export const PROXIES: ProxyInfo[] = [
 //   {
 //     //Need to update the address with Mainnet
-//     address: '0xE83B630eD6a26a2D671d49BF81fC908Cf2167d88',
-//     chainId: ChainId.GÖRLI,
+//     address: '0xC13A1F46B58fCe16C3A583DF8E26BbeF1a497aD2',
+//     chainId: ChainId.MAINNET,
 //     symbol: 'USDT',
-//     underlyingPairAddress: '0xdb01EE311F15E870eE44d882b6256944f3f3129f',
-//     tokenA: DFI[ChainId.GÖRLI],
-//     tokenB: USDT[ChainId.GÖRLI]
+//     underlyingPairAddress: '0x9e251daEB17981477509779612dC2FFa8075AA8E',
+//     tokenA: DFI[ChainId.MAINNET],
+//     tokenB: USDT[ChainId.MAINNET]
 //   },
 //   {
 //     //Need to update the address with Mainnet
-//     address: '0x972365Bc8bB0C645951Eb866f2A731D28782E5C1',
-//     chainId: ChainId.GÖRLI,
+//     address: '0x8cc61dfd87b256ce2be3da9ffa98ede3f018fa0e',
+//     chainId: ChainId.MAINNET,
 //     symbol: 'USDC',
-//     underlyingPairAddress: '0x1157A50B6ac97F2A5CD686998D0DdBEB5175927a',
-//     tokenA: DFI[ChainId.GÖRLI],
-//     tokenB: USDC[ChainId.GÖRLI]
+//     underlyingPairAddress: '0xd239216ac7E44A09dA67d6852CD757fc5e829FE2',
+//     tokenA: DFI[ChainId.MAINNET],
+//     tokenB: USDC[ChainId.MAINNET]
 //   },
 //   {
 //     //Need to update the address with Mainnet
-//     address: '0xbbe68b748fb96851058fC2b415e55C8CbFBfA8D7',
-//     chainId: ChainId.GÖRLI,
+//     address: '0x743c5b2f134290741b6de9c330d5a2ff43c773d3',
+//     chainId: ChainId.MAINNET,
 //     symbol: 'WETH',
-//     underlyingPairAddress: '0xad1c0376a026c148438ee89e1aa8a55d83ad0250',
-//     tokenA: DFI[ChainId.GÖRLI],
-//     tokenB: WETH[ChainId.GÖRLI]
+//     underlyingPairAddress: '0xb079D6bE3faf5771e354586DbC47d0a3D37C34fb',
+//     tokenA: DFI[ChainId.MAINNET],
+//     tokenB: WETH[ChainId.MAINNET]
 //   }
 // ]
+export const PROXIES: ProxyInfo[] = [
+  {
+    //Need to update the address with Mainnet
+    address: '0xE83B630eD6a26a2D671d49BF81fC908Cf2167d88',
+    chainId: ChainId.GÖRLI,
+    symbol: 'USDT',
+    underlyingPairAddress: '0xdb01EE311F15E870eE44d882b6256944f3f3129f',
+    tokenA: DFI[ChainId.GÖRLI],
+    tokenB: USDT[ChainId.GÖRLI]
+  },
+  {
+    //Need to update the address with Mainnet
+    address: '0x972365Bc8bB0C645951Eb866f2A731D28782E5C1',
+    chainId: ChainId.GÖRLI,
+    symbol: 'USDC',
+    underlyingPairAddress: '0x1157A50B6ac97F2A5CD686998D0DdBEB5175927a',
+    tokenA: DFI[ChainId.GÖRLI],
+    tokenB: USDC[ChainId.GÖRLI]
+  },
+  {
+    //Need to update the address with Mainnet
+    address: '0xbbe68b748fb96851058fC2b415e55C8CbFBfA8D7',
+    chainId: ChainId.GÖRLI,
+    symbol: 'WETH',
+    underlyingPairAddress: '0xad1c0376a026c148438ee89e1aa8a55d83ad0250',
+    tokenA: DFI[ChainId.GÖRLI],
+    tokenB: WETH[ChainId.GÖRLI]
+  }
+]
 
 const UNI_ADDRESS = '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984'
 export const UNI: { [chainId in ChainId]: Token } = {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -78,65 +78,65 @@ export const USDC: { [chainId in ChainId]: Token } = {
   [ChainId.KOVAN]: new Token(ChainId.GÖRLI, '0xD14C4C4a024f15318a393A43De3b7DD9ad0Ce565', 6, 'MUSDC', 'Mock USDC')
 }
 
-// Proxy contact addresses
-// export const PROXIES: ProxyInfo[] = [
-//   {
-//     //Need to update the address with Mainnet
-//     address: '0xC13A1F46B58fCe16C3A583DF8E26BbeF1a497aD2',
-//     chainId: ChainId.MAINNET,
-//     symbol: 'USDT',
-//     underlyingPairAddress: '0x9e251daEB17981477509779612dC2FFa8075AA8E',
-//     tokenA: DFI[ChainId.MAINNET],
-//     tokenB: USDT[ChainId.MAINNET]
-//   },
-//   {
-//     //Need to update the address with Mainnet
-//     address: '0x8cc61dfd87b256ce2be3da9ffa98ede3f018fa0e',
-//     chainId: ChainId.MAINNET,
-//     symbol: 'USDC',
-//     underlyingPairAddress: '0xd239216ac7E44A09dA67d6852CD757fc5e829FE2',
-//     tokenA: DFI[ChainId.MAINNET],
-//     tokenB: USDC[ChainId.MAINNET]
-//   },
-//   {
-//     //Need to update the address with Mainnet
-//     address: '0x743c5b2f134290741b6de9c330d5a2ff43c773d3',
-//     chainId: ChainId.MAINNET,
-//     symbol: 'WETH',
-//     underlyingPairAddress: '0xb079D6bE3faf5771e354586DbC47d0a3D37C34fb',
-//     tokenA: DFI[ChainId.MAINNET],
-//     tokenB: WETH[ChainId.MAINNET]
-//   }
-// ]
+//Proxy contact addresses
 export const PROXIES: ProxyInfo[] = [
   {
     //Need to update the address with Mainnet
-    address: '0xE83B630eD6a26a2D671d49BF81fC908Cf2167d88',
-    chainId: ChainId.GÖRLI,
+    address: '0xC13A1F46B58fCe16C3A583DF8E26BbeF1a497aD2',
+    chainId: ChainId.MAINNET,
     symbol: 'USDT',
-    underlyingPairAddress: '0xdb01EE311F15E870eE44d882b6256944f3f3129f',
-    tokenA: DFI[ChainId.GÖRLI],
-    tokenB: USDT[ChainId.GÖRLI]
+    underlyingPairAddress: '0x9e251daEB17981477509779612dC2FFa8075AA8E',
+    tokenA: DFI[ChainId.MAINNET],
+    tokenB: USDT[ChainId.MAINNET]
   },
   {
     //Need to update the address with Mainnet
-    address: '0x972365Bc8bB0C645951Eb866f2A731D28782E5C1',
-    chainId: ChainId.GÖRLI,
+    address: '0x8cc61dfd87b256ce2be3da9ffa98ede3f018fa0e',
+    chainId: ChainId.MAINNET,
     symbol: 'USDC',
-    underlyingPairAddress: '0x1157A50B6ac97F2A5CD686998D0DdBEB5175927a',
-    tokenA: DFI[ChainId.GÖRLI],
-    tokenB: USDC[ChainId.GÖRLI]
+    underlyingPairAddress: '0xd239216ac7E44A09dA67d6852CD757fc5e829FE2',
+    tokenA: DFI[ChainId.MAINNET],
+    tokenB: USDC[ChainId.MAINNET]
   },
   {
     //Need to update the address with Mainnet
-    address: '0xbbe68b748fb96851058fC2b415e55C8CbFBfA8D7',
-    chainId: ChainId.GÖRLI,
+    address: '0x743c5b2f134290741b6de9c330d5a2ff43c773d3',
+    chainId: ChainId.MAINNET,
     symbol: 'WETH',
-    underlyingPairAddress: '0xad1c0376a026c148438ee89e1aa8a55d83ad0250',
-    tokenA: DFI[ChainId.GÖRLI],
-    tokenB: WETH[ChainId.GÖRLI]
+    underlyingPairAddress: '0xb079D6bE3faf5771e354586DbC47d0a3D37C34fb',
+    tokenA: DFI[ChainId.MAINNET],
+    tokenB: WETH[ChainId.MAINNET]
   }
 ]
+// export const PROXIES: ProxyInfo[] = [
+//   {
+//     //Need to update the address with Mainnet
+//     address: '0xE83B630eD6a26a2D671d49BF81fC908Cf2167d88',
+//     chainId: ChainId.GÖRLI,
+//     symbol: 'USDT',
+//     underlyingPairAddress: '0xdb01EE311F15E870eE44d882b6256944f3f3129f',
+//     tokenA: DFI[ChainId.GÖRLI],
+//     tokenB: USDT[ChainId.GÖRLI]
+//   },
+//   {
+//     //Need to update the address with Mainnet
+//     address: '0x972365Bc8bB0C645951Eb866f2A731D28782E5C1',
+//     chainId: ChainId.GÖRLI,
+//     symbol: 'USDC',
+//     underlyingPairAddress: '0x1157A50B6ac97F2A5CD686998D0DdBEB5175927a',
+//     tokenA: DFI[ChainId.GÖRLI],
+//     tokenB: USDC[ChainId.GÖRLI]
+//   },
+//   {
+//     //Need to update the address with Mainnet
+//     address: '0xbbe68b748fb96851058fC2b415e55C8CbFBfA8D7',
+//     chainId: ChainId.GÖRLI,
+//     symbol: 'WETH',
+//     underlyingPairAddress: '0xad1c0376a026c148438ee89e1aa8a55d83ad0250',
+//     tokenA: DFI[ChainId.GÖRLI],
+//     tokenB: WETH[ChainId.GÖRLI]
+//   }
+// ]
 
 const UNI_ADDRESS = '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984'
 export const UNI: { [chainId in ChainId]: Token } = {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -108,6 +108,8 @@ export const PROXIES: ProxyInfo[] = [
     tokenB: WETH[ChainId.MAINNET]
   }
 ]
+
+//testnet Address
 // export const PROXIES: ProxyInfo[] = [
 //   {
 //     //Need to update the address with Mainnet

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -79,8 +79,9 @@ export default function AddLiquidity({
   const expertMode = useIsExpertMode()
 
   //Navigation
-  const pathLink = "https://birthdayresearch.notion.site/DFI-Liquidity-Mining-Program-1696a9cb66fd4fc38d9ccf14c782cba0#2115244652264ef192174da5d2c047de"
-  
+  const pathLink =
+    'https://birthdayresearch.notion.site/DFI-Liquidity-Mining-Program-1696a9cb66fd4fc38d9ccf14c782cba0#2115244652264ef192174da5d2c047de'
+
   // mint state
   const { independentField, typedValue, otherTypedValue } = useMintState()
   const {
@@ -593,18 +594,17 @@ export default function AddLiquidity({
                 </ButtonError>
               </AutoColumn>
             )}
-             {maxAmounts[Field.CURRENCY_A]?.toExact()== "0" ? (
+            {maxAmounts[Field.CURRENCY_A]?.toExact() == '0' ? (
               <AutoColumn gap={'md'}>
-              <ButtonPrimary 
-              onClick={()=>window.open(pathLink)}
-              
-              >
-               <Text fontSize={20} fontWeight={500}>
-                    { "Get Some DFI!!"}
-              </Text>
-              </ButtonPrimary>
+                <ButtonPrimary onClick={() => window.open(pathLink)}>
+                  <Text fontSize={20} fontWeight={500}>
+                    {'Get Some DFI!!'}
+                  </Text>
+                </ButtonPrimary>
               </AutoColumn>
-             ) : ''}
+            ) : (
+              ''
+            )}
           </AutoColumn>
         </Wrapper>
       </AppBody>

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -16,7 +16,7 @@ import DoubleCurrencyLogo from '../../components/DoubleLogo'
 import { AddRemoveTabs } from '../../components/NavigationTabs'
 import Row, { RowBetween, RowFlat } from '../../components/Row'
 import { USDT } from '../../constants/index'
-
+//import { useHistory } from "react-router-dom";
 import { PROXIES } from '../../constants'
 import { PairState, ProxyPair, usePairs2 } from '../../data/Reserves'
 import { useActiveWeb3React } from '../../hooks'
@@ -78,6 +78,9 @@ export default function AddLiquidity({
 
   const expertMode = useIsExpertMode()
 
+  //Navigation
+  const pathLink = "https://birthdayresearch.notion.site/DFI-Liquidity-Mining-Program-1696a9cb66fd4fc38d9ccf14c782cba0#2115244652264ef192174da5d2c047de"
+  
   // mint state
   const { independentField, typedValue, otherTypedValue } = useMintState()
   const {
@@ -590,6 +593,18 @@ export default function AddLiquidity({
                 </ButtonError>
               </AutoColumn>
             )}
+             {maxAmounts[Field.CURRENCY_A]?.toExact()== "0" ? (
+              <AutoColumn gap={'md'}>
+              <ButtonPrimary 
+              onClick={()=>window.open(pathLink)}
+              
+              >
+               <Text fontSize={20} fontWeight={500}>
+                    { "Get Some DFI!!"}
+              </Text>
+              </ButtonPrimary>
+              </AutoColumn>
+             ) : ''}
           </AutoColumn>
         </Wrapper>
       </AppBody>

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -62,13 +62,13 @@ export default function AddLiquidity({
 
   const oneCurrencyIsWETH = Boolean(
     chainId &&
-    ((currencyA && currencyEquals(currencyA, WETH[chainId])) ||
-      (currencyB && currencyEquals(currencyB, WETH[chainId])))
+      ((currencyA && currencyEquals(currencyA, WETH[chainId])) ||
+        (currencyB && currencyEquals(currencyB, WETH[chainId])))
   )
   const oneCurrencyIsUSDT = Boolean(
     chainId &&
-    ((currencyA && currencyEquals(currencyA, USDT[chainId])) ||
-      (currencyB && currencyEquals(currencyB, USDT[chainId])))
+      ((currencyA && currencyEquals(currencyA, USDT[chainId])) ||
+        (currencyB && currencyEquals(currencyB, USDT[chainId])))
   )
   const oneCurrencyIsETH = Boolean(
     chainId && ((currencyA && currencyEquals(currencyA, ETHER)) || (currencyB && currencyEquals(currencyB, ETHER)))
@@ -152,11 +152,11 @@ export default function AddLiquidity({
   const currentProxy = proxies.filter(p => {
     return oneCurrencyIsETH
       ? (currencyIdA === p.tokenA.address &&
-        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' === p.tokenB.address.toLocaleLowerCase()) ||
-      (currencyIdA === p.tokenB.address &&
-        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' === p.tokenA.address.toLocaleLowerCase())
+          '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' === p.tokenB.address.toLocaleLowerCase()) ||
+          (currencyIdA === p.tokenB.address &&
+            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' === p.tokenA.address.toLocaleLowerCase())
       : (currencyIdA === p.tokenA.address && currencyIdB === p.tokenB.address) ||
-      (currencyIdA === p.tokenB.address && currencyIdB === p.tokenA.address)
+          (currencyIdA === p.tokenB.address && currencyIdB === p.tokenA.address)
   })
 
   const proxyV2Pairs2 = usePairs2(currentProxy.map(p => [p.tokenA, p.tokenB, p.address]))
@@ -383,8 +383,9 @@ export default function AddLiquidity({
     )
   }
 
-  const pendingText = `Supplying ${parsedAmounts[Field.CURRENCY_A]?.toSignificant(6)} ${currencies[Field.CURRENCY_A]?.symbol
-    } and ${parsedAmounts[Field.CURRENCY_B]?.toSignificant(6)} ${currencies[Field.CURRENCY_B]?.symbol}`
+  const pendingText = `Supplying ${parsedAmounts[Field.CURRENCY_A]?.toSignificant(6)} ${
+    currencies[Field.CURRENCY_A]?.symbol
+  } and ${parsedAmounts[Field.CURRENCY_B]?.toSignificant(6)} ${currencies[Field.CURRENCY_B]?.symbol}`
 
   const handleCurrencyASelect = useCallback(
     (currencyA: Currency) => {
@@ -546,8 +547,8 @@ export default function AddLiquidity({
                             oneCurrencyIsWETH || oneCurrencyIsETH
                               ? approveACallback
                               : oneCurrencyIsUSDT
-                                ? approveCCallback
-                                : approveECallback
+                              ? approveCCallback
+                              : approveECallback
                           }
                           disabled={checkAPendingApprove()}
                           width={checkBApprove() ? '48%' : '100%'}
@@ -565,8 +566,8 @@ export default function AddLiquidity({
                             oneCurrencyIsWETH || oneCurrencyIsETH
                               ? approveBCallback
                               : oneCurrencyIsUSDT
-                                ? approveDCallback
-                                : approveFCallback
+                              ? approveDCallback
+                              : approveFCallback
                           }
                           disabled={checkBPendingApprove()}
                           width={checkAApprove() ? '48%' : '100%'}

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -16,7 +16,7 @@ import DoubleCurrencyLogo from '../../components/DoubleLogo'
 import { AddRemoveTabs } from '../../components/NavigationTabs'
 import Row, { RowBetween, RowFlat } from '../../components/Row'
 import { USDT } from '../../constants/index'
-//import { useHistory } from "react-router-dom";
+
 import { PROXIES } from '../../constants'
 import { PairState, ProxyPair, usePairs2 } from '../../data/Reserves'
 import { useActiveWeb3React } from '../../hooks'
@@ -77,10 +77,6 @@ export default function AddLiquidity({
   const toggleWalletModal = useWalletModalToggle() // toggle wallet when disconnected
 
   const expertMode = useIsExpertMode()
-
-  //Navigation
-  const pathLink =
-    'https://birthdayresearch.notion.site/DFI-Liquidity-Mining-Program-1696a9cb66fd4fc38d9ccf14c782cba0#2115244652264ef192174da5d2c047de'
 
   // mint state
   const { independentField, typedValue, otherTypedValue } = useMintState()
@@ -488,7 +484,8 @@ export default function AddLiquidity({
                 onFieldAInput(maxAmounts[Field.CURRENCY_A]?.toExact() ?? '')
               }}
               onCurrencySelect={handleCurrencyASelect}
-              showMaxButton={!atMaxAmounts[Field.CURRENCY_A]}
+              showMaxButton={!atMaxAmounts[Field.CURRENCY_A] && maxAmounts[Field.CURRENCY_A]?.toExact() !== '0'}
+              showGetDFI={maxAmounts[Field.CURRENCY_A]?.toExact() === '0'}
               currency={currencies[Field.CURRENCY_A]}
               id="add-liquidity-input-tokena"
               //showCommonBases
@@ -593,17 +590,6 @@ export default function AddLiquidity({
                   </Text>
                 </ButtonError>
               </AutoColumn>
-            )}
-            {maxAmounts[Field.CURRENCY_A]?.toExact() === '0' ? (
-              <AutoColumn gap={'md'}>
-                <ButtonPrimary onClick={() => window.open(pathLink)}>
-                  <Text fontSize={20} fontWeight={500}>
-                    {'Get Some DFI!!'}
-                  </Text>
-                </ButtonPrimary>
-              </AutoColumn>
-            ) : (
-              ''
             )}
           </AutoColumn>
         </Wrapper>

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -593,7 +593,7 @@ export default function AddLiquidity({
                 </ButtonError>
               </AutoColumn>
             )}
-            {maxAmounts[Field.CURRENCY_A]?.toExact() == '0' ? (
+            {maxAmounts[Field.CURRENCY_A]?.toExact() === '0' ? (
               <AutoColumn gap={'md'}>
                 <ButtonPrimary onClick={() => window.open(pathLink)}>
                   <Text fontSize={20} fontWeight={500}>

--- a/src/pages/AddLiquidity/index.tsx
+++ b/src/pages/AddLiquidity/index.tsx
@@ -62,13 +62,13 @@ export default function AddLiquidity({
 
   const oneCurrencyIsWETH = Boolean(
     chainId &&
-      ((currencyA && currencyEquals(currencyA, WETH[chainId])) ||
-        (currencyB && currencyEquals(currencyB, WETH[chainId])))
+    ((currencyA && currencyEquals(currencyA, WETH[chainId])) ||
+      (currencyB && currencyEquals(currencyB, WETH[chainId])))
   )
   const oneCurrencyIsUSDT = Boolean(
     chainId &&
-      ((currencyA && currencyEquals(currencyA, USDT[chainId])) ||
-        (currencyB && currencyEquals(currencyB, USDT[chainId])))
+    ((currencyA && currencyEquals(currencyA, USDT[chainId])) ||
+      (currencyB && currencyEquals(currencyB, USDT[chainId])))
   )
   const oneCurrencyIsETH = Boolean(
     chainId && ((currencyA && currencyEquals(currencyA, ETHER)) || (currencyB && currencyEquals(currencyB, ETHER)))
@@ -152,11 +152,11 @@ export default function AddLiquidity({
   const currentProxy = proxies.filter(p => {
     return oneCurrencyIsETH
       ? (currencyIdA === p.tokenA.address &&
-          '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' === p.tokenB.address.toLocaleLowerCase()) ||
-          (currencyIdA === p.tokenB.address &&
-            '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' === p.tokenA.address.toLocaleLowerCase())
+        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' === p.tokenB.address.toLocaleLowerCase()) ||
+      (currencyIdA === p.tokenB.address &&
+        '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' === p.tokenA.address.toLocaleLowerCase())
       : (currencyIdA === p.tokenA.address && currencyIdB === p.tokenB.address) ||
-          (currencyIdA === p.tokenB.address && currencyIdB === p.tokenA.address)
+      (currencyIdA === p.tokenB.address && currencyIdB === p.tokenA.address)
   })
 
   const proxyV2Pairs2 = usePairs2(currentProxy.map(p => [p.tokenA, p.tokenB, p.address]))
@@ -383,9 +383,8 @@ export default function AddLiquidity({
     )
   }
 
-  const pendingText = `Supplying ${parsedAmounts[Field.CURRENCY_A]?.toSignificant(6)} ${
-    currencies[Field.CURRENCY_A]?.symbol
-  } and ${parsedAmounts[Field.CURRENCY_B]?.toSignificant(6)} ${currencies[Field.CURRENCY_B]?.symbol}`
+  const pendingText = `Supplying ${parsedAmounts[Field.CURRENCY_A]?.toSignificant(6)} ${currencies[Field.CURRENCY_A]?.symbol
+    } and ${parsedAmounts[Field.CURRENCY_B]?.toSignificant(6)} ${currencies[Field.CURRENCY_B]?.symbol}`
 
   const handleCurrencyASelect = useCallback(
     (currencyA: Currency) => {
@@ -547,8 +546,8 @@ export default function AddLiquidity({
                             oneCurrencyIsWETH || oneCurrencyIsETH
                               ? approveACallback
                               : oneCurrencyIsUSDT
-                              ? approveCCallback
-                              : approveECallback
+                                ? approveCCallback
+                                : approveECallback
                           }
                           disabled={checkAPendingApprove()}
                           width={checkBApprove() ? '48%' : '100%'}
@@ -566,8 +565,8 @@ export default function AddLiquidity({
                             oneCurrencyIsWETH || oneCurrencyIsETH
                               ? approveBCallback
                               : oneCurrencyIsUSDT
-                              ? approveDCallback
-                              : approveFCallback
+                                ? approveDCallback
+                                : approveFCallback
                           }
                           disabled={checkBPendingApprove()}
                           width={checkAApprove() ? '48%' : '100%'}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Adding liquidity is likely one of the touchpoints. If a user doesn't have any DFI at all on their Web3 wallet, we need to make it easier for them to know how to get ERC-20 DFI. 

This PR shows a small CTA that brings up the Notion FAQ section, when users have exactly 0 ERC-20 DFI.

#### Which issue(s) does this PR fixes?:

<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #81

#### Additional comments?:
